### PR TITLE
Allow lookup functions to return via callback or return value

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,28 +12,40 @@ A dirt simple Node.js module for working with US state names and abbreviations.
 
 Require madison:
 
-    var madison = require('madison');
+```js
+var madison = require('madison');
+```
 
-Get a state's abbreviation asynchronously:
+Get a state's abbreviation via callback:
 
-    madison.getStateAbbrev('virginia', function (abbrev) {
-      console.log(abbrev); //'VA'
-    });
+```js
+madison.getStateAbbrev('virginia', function (abbrev) {
+  console.log(abbrev); //'VA'
+});
+```
 
-Get a state's abbreviation synchronously:
+Get a state's abbreviation via return value:
 
-    madison.getStateAbbrevSync('virginia'); //returns 'VA'
+```js
+madison.getStateAbbrev('virginia'); //returns 'VA'
+```
 
-Get a state's name asynchronously:
+Get a state's name via callback:
 
-    madison.getStateName('va', function (name) {
-      console.log(name); //'Virginia'
-    });
+```js
+madison.getStateName('va', function (name) {
+  console.log(name); //'Virginia'
+});
+```
 
-Get a state's name synchronously:
+Get a state's name via return value:
 
-    madison.getStateNameSync('va'); //returns 'Virginia'
+```js
+madison.getStateName('va'); //returns 'Virginia'
+```
 
 Get a JSON array of US states, each containing 'name' and 'abbr' properties:
 
-    madison.states;
+```js
+madison.states;
+```

--- a/lib/madison.js
+++ b/lib/madison.js
@@ -17,22 +17,21 @@ for (var i=0; i<states.length; i++) {
 // exports
 exports.states = states;
 
-exports.getStateAbbrev = function (stateName, callback) {
+var getStateAbbrev = exports.getStateAbbrev = function (stateName, callback) {
   var stateNameLower = setNameOrAbbrevVar(stateName);
-  callback(stateAbbrevs[stateNameLower]);
-};
-
-exports.getStateAbbrevSync = function (stateName) {
-  var stateNameLower = setNameOrAbbrevVar(stateName);
+  if (typeof arguments[1] == 'function') {
+    return callback(stateAbbrevs[stateNameLower]);
+  }
   return stateAbbrevs[stateNameLower];
 };
 
-exports.getStateName = function (stateAbbrev, callback) {
-  var stateAbbr = setNameOrAbbrevVar(stateAbbrev);
-  callback(stateNames[stateAbbr]);
-};
+exports.getStateAbbrevSync = getStateAbbrev;
 
-exports.getStateNameSync = function (stateAbbrev) {
+var getStateName = exports.getStateName = function (stateAbbrev, callback) {
   var stateAbbr = setNameOrAbbrevVar(stateAbbrev);
+  if (typeof arguments[1] == 'function') {
+    return callback(stateNames[stateAbbr]);
+  }
   return stateNames[stateAbbr];
 };
+exports.getStateNameSync = getStateName;


### PR DESCRIPTION
While implementing this library in a project, I noticed the readme stated `getStateAbbrev()` and `getStateName()` were asynchronous, but the functionality is fully synchronous, it only returns via callback. This led me to see some simplifications we could make to the library, without altering the API.

**Changes**
* `getStateAbbrev()` and `getStateName()` will now examine their arguments list, and if the second argument is a function, it will return via callback. Otherwise, it will simply return.
* `getStateAbbrevSync()` and `getStateNameSync()` are now just aliases to `getStateAbbrev()` and `getStateName()`
* Readme has been updated to record these changes, and essentially deprecate `getStateAbbrevSync()` and `getStateNameSync()` by delisting them. Also, syntax highlighting

All test should pass. Thanks for considering!